### PR TITLE
Sdq 3413 blog author

### DIFF
--- a/content/blog/hello-world/index.md
+++ b/content/blog/hello-world/index.md
@@ -6,6 +6,7 @@ featuredImageCredit: "Markus Spiske"
 featuredImageLink: "https://unsplash.com/photos/70Rir5vB96U"
 tags: ["first", "hello_world"]
 title: Hello World
+postAuthor: ""
 ---
 
 # Welcome to our first post on our open source and technology site! 🎉

--- a/src/components/BlogPosts.js
+++ b/src/components/BlogPosts.js
@@ -17,6 +17,8 @@ const PostsList = ({ author, posts }) => {
     <div className="posts-list">
         {posts.map((post, index) => {
           const featuredImgFluid= post.frontmatter?.featuredImage?.childImageSharp?.fluid
+          // Use individual author if available, fallback to generic site author
+          const displayAuthor = post.frontmatter.postAuthor || author;
 
           return (
             <article
@@ -46,9 +48,9 @@ const PostsList = ({ author, posts }) => {
                 </h2>
                 <p className="is-size-7">
                   <em>
-                    {author &&
+                    {displayAuthor &&
                       <>
-                        By <Link to="/">{author}</Link> on {` `}
+                        By <Link to="/">{displayAuthor}</Link> on {` `}
                       </>
                     }
                     {post.frontmatter.date}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,6 +14,9 @@ const IndexPage = ({ data, location }) => {
   const posts = data.allMarkdownRemark.nodes
   const siteTitle = data.site.siteMetadata?.title || `Title`
 
+  console.log('inside indexpage')
+  console.log(data.site)
+
   return (
     <Layout location={location} title={siteTitle}>
       <SEO title="Home" />
@@ -56,6 +59,7 @@ export const pageQuery = graphql`
           }
           tags
           title
+          postAuthor
         }
       }
     }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,9 +14,6 @@ const IndexPage = ({ data, location }) => {
   const posts = data.allMarkdownRemark.nodes
   const siteTitle = data.site.siteMetadata?.title || `Title`
 
-  console.log('inside indexpage')
-  console.log(data.site)
-
   return (
     <Layout location={location} title={siteTitle}>
       <SEO title="Home" />

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -147,8 +147,8 @@ const PostsNav = ({ next, previous }) => {
 
 
 const BlogPostTemplate = ({ data, pageContext, location }) => {
-  const author = data.site.siteMetadata?.author?.name
   const post = data.markdownRemark
+  const author = post.frontmatter.postAuthor || data.site.siteMetadata?.author?.name
   const { previous, next } = pageContext
 
   const siteTitle = data.site.siteMetadata?.title || `Title`
@@ -210,6 +210,7 @@ export const pageQuery = graphql`
         featuredImageLink
         tags
         title
+        postAuthor
       }
     }
   }


### PR DESCRIPTION
Backwards compatible addition of 'postAuthor' key to gatsby frontmatter metadata.

Blog post writers can now optionally enter their name as the author which will show up on the list of blog posts and the post page itself. If no postAuthor is defined, the property will fall back to siteMetadata.author property as defined in gatsby-config.js, which was the previous behaviour.

![image](https://user-images.githubusercontent.com/106831993/183499925-cfebc0f4-70f4-4ef2-95a8-29b2dda92c9a.png)
